### PR TITLE
fix(deps): resolve aiohttp security alerts

### DIFF
--- a/MonitoringForUpdateStratagia/requirements.txt
+++ b/MonitoringForUpdateStratagia/requirements.txt
@@ -1,5 +1,5 @@
 apscheduler==3.9.1
-aiohttp==3.14.1
+aiohttp==3.14.3
 python-telegram-bot==20.0
 requests==2.33.0
 python-dotenv==1.2.2


### PR DESCRIPTION
## Что изменено
- `aiohttp` обновлён с `3.14.1` до `3.14.3`.

## Зачем
Устраняет Dependabot alerts CVE-2026-69244 (High), CVE-2026-59881 и CVE-2026-69243.

## Совместимость
Патч-обновление внутри ветки 3.14.x. Изменён только `MonitoringForUpdateStratagia/requirements.txt`.

## Проверка
Перед слиянием требуется собрать Docker-образ и выполнить smoke-тест запуска бота. PR создан как draft и не будет слит без подтверждения владельца.